### PR TITLE
fix: version format changes, added legacy-format flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,221 +1,444 @@
-Esper SDK for Python
-==================
+# Esper SDK for Python
 
 [![Build Status](https://travis-ci.com/esper-io/esper-client-py.svg?branch=master)](https://travis-ci.com/esper-io/esper-client-py) [![Gitter](https://badges.gitter.im/esper-dev/esper-sdk.svg)](https://gitter.im/esper-dev/esper-sdk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Esper provides a Python client library to communicate with the Esper APIs to programmatically control and monitor your enterprise's Android-based Dedicated Devices using Esper Manage. To read more about the various capabilities of Esper Manage and Esper managed devices, please visit [esper.io](https://esper.io).
+**Esper SDK for Python** is a comprehensive Python client library that enables programmatic interaction with the Esper Manage platform APIs. Esper Manage is an enterprise-grade Android Device Management (MDM/EMM) solution designed for managing dedicated Android devices at scale.
 
+- **API version**: 1.0.0
+- **Package version**: 0.1.2
 
-- API version: 1.0.0
-- Package version: 0.1.2
+## What is Esper Manage?
 
+Esper Manage is a cloud-based Android Enterprise Mobile Device Management (MDM/EMM) platform that provides:
 
-## Requirements.
+- **Device Management**: Monitor, configure, and control Android devices remotely
+- **Application Management**: Upload, distribute, and manage applications across device fleets
+- **Policy Enforcement**: Configure device settings, security policies, and restrictions
+- **Remote Commands**: Execute commands on devices remotely (reboot, lock, factory reset, etc.)
+- **Geofencing**: Define location-based policies and triggers
+- **Content Management**: Distribute files and content to devices
+- **Event Subscriptions**: Subscribe to device events and webhooks
+- **Device Grouping**: Organize devices into groups for bulk operations
 
-Python 3.4+
+## What Does This Library Do?
 
-Additionally, you need a dedicated Esper environment set up on Esper Cloud through our Esper Dev Trial. For more details checkout [Esper Requirements](https://docs.esper.io/home/pythonsdk.html#pre-requisites)
+The `esper-client-py` library provides a Python interface to interact with all Esper Manage APIs. It abstracts the complexity of HTTP requests, authentication, and data serialization, allowing developers to:
+
+- **Manage Devices**: Query device lists, get device details, check device status, and manage device groups
+- **Handle Applications**: Upload APK files, manage application versions, track installations, and view app permissions
+- **Execute Commands**: Send remote commands to individual devices or device groups, check command status, and view command history
+- **Configure Policies**: Create and manage enterprise policies for device security, updates, and restrictions
+- **Manage Content**: Upload and distribute files to devices
+- **Set Up Geofences**: Create and manage geofences for location-based device management
+- **Subscribe to Events**: Set up event subscriptions for real-time device event notifications
+- **Manage Authentication**: Handle API tokens and authentication
+
+## Use Cases
+
+### 1. **Enterprise Device Fleet Management**
+Manage large fleets of Android devices deployed across multiple locations:
+- Automate device provisioning and enrollment
+- Monitor device health and status at scale
+- Apply consistent configurations across device groups
+- Track device inventory and compliance
+
+### 2. **Application Deployment Automation**
+Automate application lifecycle management:
+- Upload new app versions programmatically
+- Deploy applications to specific devices or groups
+- Track installation status across devices
+- Manage app updates and rollbacks
+
+### 3. **Remote Device Control**
+Execute remote operations on devices:
+- Reboot devices remotely
+- Lock/unlock devices
+- Factory reset devices
+- Change device settings (WiFi, Bluetooth, GPS, etc.)
+- Install/uninstall applications remotely
+
+### 4. **Policy and Compliance Management**
+Enforce security and compliance policies:
+- Configure device password policies
+- Set up device update policies
+- Manage Google account permissions
+- Enforce device restrictions
+
+### 5. **Location-Based Management**
+Implement geofencing for location-aware device management:
+- Create geofences around specific locations
+- Trigger actions when devices enter/exit geofences
+- Enforce location-based policies
+
+### 6. **Integration and Automation**
+Build custom integrations and automation:
+- Integrate Esper Manage with existing IT systems
+- Automate device onboarding workflows
+- Create custom dashboards and reporting tools
+- Build CI/CD pipelines for app deployment
+
+### 7. **Monitoring and Alerting**
+Set up monitoring and alerting systems:
+- Subscribe to device events
+- Monitor device status changes
+- Track application installations
+- Receive notifications for device issues
+
+## Requirements
+
+- **Python**: 3.4 or higher
+- **Esper Account**: A dedicated Esper environment set up on Esper Cloud through [Esper Dev Trial](https://docs.esper.io/home/pythonsdk.html#pre-requisites)
 
 ## Installation
 
-#### Using `pip install`
+### Using `pip install`
 
-From PyPI
+**From PyPI:**
 ```sh
 pip install esperclient
 ```
 
-or
-
-From [Github](https://github.com/esper-io/esper-client-py)
+**From GitHub:**
 ```sh
 pip install git+https://github.com/esper-io/esper-client-py.git
 ```
 
-#### From source
+### From Source
 
-Download/Clone the project and install via [Setuptools](http://pypi.python.org/pypi/setuptools).
+Download/Clone the project and install via [Setuptools](http://pypi.python.org/pypi/setuptools):
 
 ```sh
 git clone https://github.com/esper-io/esper-client-py.git
-
 cd esper-client-py
-
 python setup.py install
 ```
 
-> You need not install setuptools separately, they are packaged along with downloaded library
-
+> **Note**: Setuptools are packaged along with the downloaded library, so you don't need to install them separately.
 
 ## Getting Started
 
-Please follow the [installation procedure](#installation) stated above and then run the following:
+### Basic Setup
 
+1. **Configure API credentials:**
 ```python
 import esperclient
 from esperclient.rest import ApiException
 
-# Configure API key authorization: apiKey
+# Configure API key authorization
 configuration = esperclient.Configuration()
-configuration.host = 'SERVER_URL'
-configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+configuration.host = 'https://your-environment.esper.cloud/api'  # Your Esper environment URL
+configuration.api_key['Authorization'] = 'YOUR_API_KEY'  # Your API key from Esper dashboard
 configuration.api_key_prefix['Authorization'] = 'Bearer'
 
-# create an instance of the API class
-api_instance = esperclient.DeviceApi(esperclient.ApiClient(configuration))
-enterprise_id = 'enterprise_id_example' # str | ID of the enterprise
+# Create an API client instance
+api_client = esperclient.ApiClient(configuration)
+```
+
+2. **Example: Fetch all devices in an enterprise**
+```python
+# Create an instance of the Device API
+device_api = esperclient.DeviceApi(api_client)
+enterprise_id = 'your-enterprise-id'  # Your enterprise UUID
 
 try:
-    # Fetch all devices in an enterprise
-    api_response = api_instance.get_all_devices(enterprise_id)
-    print(api_response)
+    # Fetch all devices
+    devices_response = device_api.get_all_devices(enterprise_id)
+    print(f"Total devices: {devices_response.count}")
+    for device in devices_response.results:
+        print(f"Device: {device.device_name} - Status: {device.current_state}")
 except ApiException as e:
-    print("Exception when calling DeviceApi->get_all_devices: %s\n" % e)
+    print(f"Exception when calling DeviceApi->get_all_devices: {e}")
 ```
+
+### Common Use Cases Examples
+
+#### Upload and Install an Application
+
+```python
+application_api = esperclient.ApplicationApi(api_client)
+
+# Upload an APK file
+with open('path/to/your/app.apk', 'rb') as apk_file:
+    try:
+        upload_response = application_api.upload(
+            enterprise_id,
+            file=apk_file,
+            application_name='My App',
+            package_name='com.example.myapp'
+        )
+        print(f"Application uploaded: {upload_response.id}")
+    except ApiException as e:
+        print(f"Error uploading application: {e}")
+```
+
+#### Send a Remote Command to a Device
+
+```python
+from esperclient.models import V0CommandRequest, V0CommandArgs, V0DeviceCommandEnum
+
+commands_api = esperclient.CommandsV2Api(api_client)
+
+# Create a command request
+command_request = V0CommandRequest(
+    command=V0DeviceCommandEnum.REBOOT,  # Command type
+    device_ids=[device_id],  # List of device UUIDs
+    args=V0CommandArgs()  # Optional command arguments
+)
+
+try:
+    response = commands_api.create_command(enterprise_id, command_request)
+    print(f"Command created: {response.id}")
+    
+    # Check command status
+    status = commands_api.get_command_request_status(enterprise_id, response.id)
+    print(f"Command status: {status.status}")
+except ApiException as e:
+    print(f"Error executing command: {e}")
+```
+
+#### Create a Device Group
+
+```python
+from esperclient.models import DeviceGroup
+
+device_group_api = esperclient.DeviceGroupApi(api_client)
+
+group = DeviceGroup(
+    name='Production Devices',
+    description='All production devices'
+)
+
+try:
+    created_group = device_group_api.create_group(enterprise_id, group)
+    print(f"Group created: {created_group.id}")
+except ApiException as e:
+    print(f"Error creating group: {e}")
+```
+
+#### Get Device Status and Events
+
+```python
+device_api = esperclient.DeviceApi(api_client)
+
+try:
+    # Get device details
+    device = device_api.get_device_by_id(enterprise_id, device_id)
+    print(f"Device: {device.device_name}")
+    print(f"Model: {device.model}")
+    print(f"Android Version: {device.android_version}")
+    
+    # Get device status/events
+    status = device_api.get_device_event(enterprise_id, device_id)
+    print(f"Current State: {status.current_state}")
+    print(f"Last Seen: {status.last_seen}")
+except ApiException as e:
+    print(f"Error fetching device info: {e}")
+```
+
+## API Reference
+
+The library provides access to the following API classes:
+
+### Core APIs
+
+| API Class | Description |
+|-----------|-------------|
+| `DeviceApi` | Manage devices, query device information, get device status |
+| `ApplicationApi` | Upload applications, manage app versions, track installations |
+| `CommandsApi` | Execute commands on individual devices (legacy) |
+| `CommandsV2Api` | Execute commands on devices or groups (recommended) |
+| `DeviceGroupApi` | Create and manage device groups |
+| `GroupCommandsApi` | Execute commands on device groups |
+
+### Management APIs
+
+| API Class | Description |
+|-----------|-------------|
+| `EnterpriseApi` | Manage enterprise settings and configuration |
+| `EnterprisePolicyApi` | Create and manage enterprise policies |
+| `ContentApi` | Upload and manage content/files |
+| `GeofenceApi` | Create and manage geofences |
+| `SubscriptionApi` | Manage event subscriptions |
+| `TokenApi` | Manage API tokens and authentication |
+
+### Complete API Documentation
+
+For detailed API documentation, see the [API Endpoints Documentation](#documentation-for-api-endpoints) section below.
 
 ## Documentation for API Endpoints
 
-Given below is a detailed documentation for each of the API endpoint along with supported request options. All URIs are relative to *https://foo-api.esper.cloud/api*
+All URIs are relative to `https://your-environment.esper.cloud/api`
 
+### Device Management
 
-Class | Method | HTTP request
------------- | ------------- | -------------
-*ApplicationApi* | [**delete_app_version**](docs/ApplicationApi.md#delete_app_version) | **DELETE** /enterprise/{enterprise_id}/application/{application_id}/version/{version_id}/
-*ApplicationApi* | [**delete_application**](docs/ApplicationApi.md#delete_application) | **DELETE** /enterprise/{enterprise_id}/application/{application_id}/
-*ApplicationApi* | [**get_all_applications**](docs/ApplicationApi.md#get_all_applications) | **GET** /enterprise/{enterprise_id}/application/
-*ApplicationApi* | [**get_app_version**](docs/ApplicationApi.md#get_app_version) | **GET** /enterprise/{enterprise_id}/application/{application_id}/version/{version_id}/
-*ApplicationApi* | [**get_app_versions**](docs/ApplicationApi.md#get_app_versions) | **GET** /enterprise/{enterprise_id}/application/{application_id}/version/
-*ApplicationApi* | [**get_application**](docs/ApplicationApi.md#get_application) | **GET** /enterprise/{enterprise_id}/application/{application_id}/
-*ApplicationApi* | [**get_install_devices**](docs/ApplicationApi.md#get_install_devices) | **GET** /enterprise/{enterprise_id}/application/{application_id}/version/{version_id}/installdevices
-*ApplicationApi* | [**upload**](docs/ApplicationApi.md#upload) | **POST** /enterprise/{enterprise_id}/application/upload/
-*CommandsApi* | [**get_command**](docs/CommandsApi.md#get_command) | **GET** /enterprise/{enterprise_id}/device/{device_id}/command/{command_id}/
-*CommandsApi* | [**run_command**](docs/CommandsApi.md#run_command) | **POST** /enterprise/{enterprise_id}/device/{device_id}/command/
-*CommandsV2Api* | [**create_command**](docs/CommandsV2Api.md#create_command) | **POST** /v0/enterprise/{enterprise_id}/command/
-*CommandsV2Api* | [**get_command_request_status**](docs/CommandsV2Api.md#get_command_request_status) | **GET** /v0/enterprise/{enterprise_id}/command/{request_id}/status/
-*CommandsV2Api* | [**get_device_command_history**](docs/CommandsV2Api.md#get_device_command_history) | **GET** /v0/enterprise/{enterprise_id}/device/{device_id}/command-history/
-*CommandsV2Api* | [**list_command_request**](docs/CommandsV2Api.md#list_command_request) | **GET** /v0/enterprise/{enterprise_id}/command/
-*ContentApi* | [**delete_content**](docs/ContentApi.md#delete_content) | **DELETE** /v0/enterprise/{enterprise_id}/content/{content_id}/
-*ContentApi* | [**get_all_content**](docs/ContentApi.md#get_all_content) | **GET** /v0/enterprise/{enterprise_id}/content/
-*ContentApi* | [**get_content**](docs/ContentApi.md#get_content) | **GET** /v0/enterprise/{enterprise_id}/content/{content_id}/
-*ContentApi* | [**patch_content**](docs/ContentApi.md#patch_content) | **PATCH** /v0/enterprise/{enterprise_id}/content/{content_id}/
-*ContentApi* | [**post_content**](docs/ContentApi.md#post_content) | **POST** /v0/enterprise/{enterprise_id}/content/upload/
-*DeviceApi* | [**get_all_devices**](docs/DeviceApi.md#get_all_devices) | **GET** /enterprise/{enterprise_id}/device/
-*DeviceApi* | [**get_app_installs**](docs/DeviceApi.md#get_app_installs) | **GET** /enterprise/{enterprise_id}/device/{device_id}/install/
-*DeviceApi* | [**get_device_app_by_id**](docs/DeviceApi.md#get_device_app_by_id) | **GET** /enterprise/{enterprise_id}/device/{device_id}/app/{app_id}/
-*DeviceApi* | [**get_device_apps**](docs/DeviceApi.md#get_device_apps) | **GET** /enterprise/{enterprise_id}/device/{device_id}/app/
-*DeviceApi* | [**get_device_by_id**](docs/DeviceApi.md#get_device_by_id) | **GET** /enterprise/{enterprise_id}/device/{device_id}/
-*DeviceApi* | [**get_device_event**](docs/DeviceApi.md#get_device_event) | **GET** /enterprise/{enterprise_id}/device/{device_id}/status/
-*DeviceGroupApi* | [**create_group**](docs/DeviceGroupApi.md#create_group) | **POST** /enterprise/{enterprise_id}/devicegroup/
-*DeviceGroupApi* | [**delete_group**](docs/DeviceGroupApi.md#delete_group) | **DELETE** /enterprise/{enterprise_id}/devicegroup/{group_id}/
-*DeviceGroupApi* | [**get_all_groups**](docs/DeviceGroupApi.md#get_all_groups) | **GET** /enterprise/{enterprise_id}/devicegroup/
-*DeviceGroupApi* | [**get_group_by_id**](docs/DeviceGroupApi.md#get_group_by_id) | **GET** /enterprise/{enterprise_id}/devicegroup/{group_id}/
-*DeviceGroupApi* | [**partial_update_group**](docs/DeviceGroupApi.md#partial_update_group) | **PATCH** /enterprise/{enterprise_id}/devicegroup/{group_id}/
-*DeviceGroupApi* | [**update_group**](docs/DeviceGroupApi.md#update_group) | **PUT** /enterprise/{enterprise_id}/devicegroup/{group_id}/
-*EnterpriseApi* | [**get_enterprise**](docs/EnterpriseApi.md#get_enterprise) | **GET** /v1/enterprise/{enterprise_id}/
-*EnterpriseApi* | [**partial_update_enterprise**](docs/EnterpriseApi.md#partial_update_enterprise) | **PATCH** /v1/enterprise/{enterprise_id}/
-*EnterprisePolicyApi* | [**create_policy**](docs/EnterprisePolicyApi.md#create_policy) | **POST** /enterprise/{enterprise_id}/policy/
-*EnterprisePolicyApi* | [**delete_enterprise_policy**](docs/EnterprisePolicyApi.md#delete_enterprise_policy) | **DELETE** /enterprise/{enterprise_id}/policy/{policy_id}/
-*EnterprisePolicyApi* | [**get_policy_by_id**](docs/EnterprisePolicyApi.md#get_policy_by_id) | **GET** /enterprise/{enterprise_id}/policy/{policy_id}/
-*EnterprisePolicyApi* | [**list_policies**](docs/EnterprisePolicyApi.md#list_policies) | **GET** /enterprise/{enterprise_id}/policy/
-*EnterprisePolicyApi* | [**partialupdate_policy**](docs/EnterprisePolicyApi.md#partialupdate_policy) | **PATCH** /enterprise/{enterprise_id}/policy/{policy_id}/
-*EnterprisePolicyApi* | [**update_policy**](docs/EnterprisePolicyApi.md#update_policy) | **PUT** /enterprise/{enterprise_id}/policy/{policy_id}/
-*GeofenceApi* | [**create_geofence**](docs/GeofenceApi.md#create_geofence) | **POST** /v0/enterprise/{enterprise_id}/geofence/
-*GeofenceApi* | [**delete_geofence**](docs/GeofenceApi.md#delete_geofence) | **DELETE** /v0/enterprise/{enterprise_id}/geofence/{geofence_id}/
-*GeofenceApi* | [**get_all_geofences**](docs/GeofenceApi.md#get_all_geofences) | **GET** /v0/enterprise/{enterprise_id}/geofence/
-*GeofenceApi* | [**get_geofence**](docs/GeofenceApi.md#get_geofence) | **GET** /v0/enterprise/{enterprise_id}/geofence/{geofence_id}/
-*GeofenceApi* | [**partial_update_geofence**](docs/GeofenceApi.md#partial_update_geofence) | **PATCH** /v0/enterprise/{enterprise_id}/geofence/{geofence_id}/
-*GeofenceApi* | [**update_geofence**](docs/GeofenceApi.md#update_geofence) | **PUT** /v0/enterprise/{enterprise_id}/geofence/{geofence_id}/
-*GroupCommandsApi* | [**get_group_command**](docs/GroupCommandsApi.md#get_group_command) | **GET** /enterprise/{enterprise_id}/devicegroup/{group_id}/command/{command_id}/
-*GroupCommandsApi* | [**run_group_command**](docs/GroupCommandsApi.md#run_group_command) | **POST** /enterprise/{enterprise_id}/devicegroup/{group_id}/command/
-*SubscriptionApi* | [**create_subscription**](docs/SubscriptionApi.md#create_subscription) | **POST** /v0/enterprise/{enterprise_id}/subscription/
-*SubscriptionApi* | [**delete_subscription**](docs/SubscriptionApi.md#delete_subscription) | **DELETE** /v0/enterprise/{enterprise_id}/subscription/{subscription_id}/
-*SubscriptionApi* | [**get_all_subscriptions**](docs/SubscriptionApi.md#get_all_subscriptions) | **GET** /v0/enterprise/{enterprise_id}/subscription/
-*SubscriptionApi* | [**get_subscription**](docs/SubscriptionApi.md#get_subscription) | **GET** /v0/enterprise/{enterprise_id}/subscription/{subscription_id}/
-*TokenApi* | [**get_token_info**](docs/TokenApi.md#get_token_info) | **GET** /v1/token-info/
-*TokenApi* | [**renew_token**](docs/TokenApi.md#renew_token) | **POST** /v0/enterprise/{enterprise_id}/developerapp/{developerapp_id}/renew-token/
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `DeviceApi` | `get_all_devices` | **GET** `/enterprise/{enterprise_id}/device/` | Fetch all devices in an enterprise |
+| `DeviceApi` | `get_device_by_id` | **GET** `/enterprise/{enterprise_id}/device/{device_id}/` | Get device details by ID |
+| `DeviceApi` | `get_device_event` | **GET** `/enterprise/{enterprise_id}/device/{device_id}/status/` | Get device status/events |
+| `DeviceApi` | `get_device_apps` | **GET** `/enterprise/{enterprise_id}/device/{device_id}/app/` | List apps installed on device |
+| `DeviceApi` | `get_app_installs` | **GET** `/enterprise/{enterprise_id}/device/{device_id}/install/` | List app installations |
 
+### Application Management
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `ApplicationApi` | `upload` | **POST** `/enterprise/{enterprise_id}/application/upload/` | Upload an APK file |
+| `ApplicationApi` | `get_all_applications` | **GET** `/enterprise/{enterprise_id}/application/` | List all applications |
+| `ApplicationApi` | `get_application` | **GET** `/enterprise/{enterprise_id}/application/{application_id}/` | Get application details |
+| `ApplicationApi` | `get_app_versions` | **GET** `/enterprise/{enterprise_id}/application/{application_id}/version/` | List app versions |
+| `ApplicationApi` | `get_install_devices` | **GET** `/enterprise/{enterprise_id}/application/{application_id}/version/{version_id}/installdevices` | Get devices with app installed |
+| `ApplicationApi` | `delete_application` | **DELETE** `/enterprise/{enterprise_id}/application/{application_id}/` | Delete an application |
+| `ApplicationApi` | `delete_app_version` | **DELETE** `/enterprise/{enterprise_id}/application/{application_id}/version/{version_id}/` | Delete an app version |
+
+### Command Execution
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `CommandsV2Api` | `create_command` | **POST** `/v0/enterprise/{enterprise_id}/command/` | Create a command request |
+| `CommandsV2Api` | `get_command_request_status` | **GET** `/v0/enterprise/{enterprise_id}/command/{request_id}/status/` | Get command status |
+| `CommandsV2Api` | `get_device_command_history` | **GET** `/v0/enterprise/{enterprise_id}/device/{device_id}/command-history/` | Get device command history |
+| `CommandsV2Api` | `list_command_request` | **GET** `/v0/enterprise/{enterprise_id}/command/` | List command requests |
+| `CommandsApi` | `run_command` | **POST** `/enterprise/{enterprise_id}/device/{device_id}/command/` | Run command on device (legacy) |
+| `GroupCommandsApi` | `run_group_command` | **POST** `/enterprise/{enterprise_id}/devicegroup/{group_id}/command/` | Run command on device group |
+
+### Device Groups
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `DeviceGroupApi` | `create_group` | **POST** `/enterprise/{enterprise_id}/devicegroup/` | Create a device group |
+| `DeviceGroupApi` | `get_all_groups` | **GET** `/enterprise/{enterprise_id}/devicegroup/` | List all device groups |
+| `DeviceGroupApi` | `get_group_by_id` | **GET** `/enterprise/{enterprise_id}/devicegroup/{group_id}/` | Get group details |
+| `DeviceGroupApi` | `update_group` | **PUT** `/enterprise/{enterprise_id}/devicegroup/{group_id}/` | Update a device group |
+| `DeviceGroupApi` | `partial_update_group` | **PATCH** `/enterprise/{enterprise_id}/devicegroup/{group_id}/` | Partially update a group |
+| `DeviceGroupApi` | `delete_group` | **DELETE** `/enterprise/{enterprise_id}/devicegroup/{group_id}/` | Delete a device group |
+
+### Enterprise & Policies
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `EnterpriseApi` | `get_enterprise` | **GET** `/v1/enterprise/{enterprise_id}/` | Get enterprise details |
+| `EnterpriseApi` | `partial_update_enterprise` | **PATCH** `/v1/enterprise/{enterprise_id}/` | Update enterprise settings |
+| `EnterprisePolicyApi` | `create_policy` | **POST** `/enterprise/{enterprise_id}/policy/` | Create an enterprise policy |
+| `EnterprisePolicyApi` | `list_policies` | **GET** `/enterprise/{enterprise_id}/policy/` | List all policies |
+| `EnterprisePolicyApi` | `get_policy_by_id` | **GET** `/enterprise/{enterprise_id}/policy/{policy_id}/` | Get policy details |
+| `EnterprisePolicyApi` | `update_policy` | **PUT** `/enterprise/{enterprise_id}/policy/{policy_id}/` | Update a policy |
+| `EnterprisePolicyApi` | `delete_enterprise_policy` | **DELETE** `/enterprise/{enterprise_id}/policy/{policy_id}/` | Delete a policy |
+
+### Content Management
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `ContentApi` | `post_content` | **POST** `/v0/enterprise/{enterprise_id}/content/upload/` | Upload content |
+| `ContentApi` | `get_all_content` | **GET** `/v0/enterprise/{enterprise_id}/content/` | List all content |
+| `ContentApi` | `get_content` | **GET** `/v0/enterprise/{enterprise_id}/content/{content_id}/` | Get content details |
+| `ContentApi` | `patch_content` | **PATCH** `/v0/enterprise/{enterprise_id}/content/{content_id}/` | Update content |
+| `ContentApi` | `delete_content` | **DELETE** `/v0/enterprise/{enterprise_id}/content/{content_id}/` | Delete content |
+
+### Geofencing
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `GeofenceApi` | `create_geofence` | **POST** `/v0/enterprise/{enterprise_id}/geofence/` | Create a geofence |
+| `GeofenceApi` | `get_all_geofences` | **GET** `/v0/enterprise/{enterprise_id}/geofence/` | List all geofences |
+| `GeofenceApi` | `get_geofence` | **GET** `/v0/enterprise/{enterprise_id}/geofence/{geofence_id}/` | Get geofence details |
+| `GeofenceApi` | `update_geofence` | **PUT** `/v0/enterprise/{enterprise_id}/geofence/{geofence_id}/` | Update a geofence |
+| `GeofenceApi` | `delete_geofence` | **DELETE** `/v0/enterprise/{enterprise_id}/geofence/{geofence_id}/` | Delete a geofence |
+
+### Event Subscriptions
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `SubscriptionApi` | `create_subscription` | **POST** `/v0/enterprise/{enterprise_id}/subscription/` | Create event subscription |
+| `SubscriptionApi` | `get_all_subscriptions` | **GET** `/v0/enterprise/{enterprise_id}/subscription/` | List all subscriptions |
+| `SubscriptionApi` | `get_subscription` | **GET** `/v0/enterprise/{enterprise_id}/subscription/{subscription_id}/` | Get subscription details |
+| `SubscriptionApi` | `delete_subscription` | **DELETE** `/v0/enterprise/{enterprise_id}/subscription/{subscription_id}/` | Delete subscription |
+
+### Authentication
+
+| Class | Method | HTTP Request | Description |
+|-------|--------|--------------|-------------|
+| `TokenApi` | `get_token_info` | **GET** `/v1/token-info/` | Get token information |
+| `TokenApi` | `renew_token` | **POST** `/v0/enterprise/{enterprise_id}/developerapp/{developerapp_id}/renew-token/` | Renew API token |
 
 ## Documentation For Models
 
- - [AppInstall](docs/AppInstall.md)
- - [AppInstallApplication](docs/AppInstallApplication.md)
- - [AppInstallVersion](docs/AppInstallVersion.md)
- - [AppPermission](docs/AppPermission.md)
- - [AppVersion](docs/AppVersion.md)
- - [Application](docs/Application.md)
- - [ApplicationVersion](docs/ApplicationVersion.md)
- - [CommandArgs](docs/CommandArgs.md)
- - [CommandRequest](docs/CommandRequest.md)
- - [Content](docs/Content.md)
- - [Data](docs/Data.md)
- - [Device](docs/Device.md)
- - [DeviceApp](docs/DeviceApp.md)
- - [DeviceAppPermission](docs/DeviceAppPermission.md)
- - [DeviceCommand](docs/DeviceCommand.md)
- - [DeviceGroup](docs/DeviceGroup.md)
- - [DeviceGroupPartialUpdate](docs/DeviceGroupPartialUpdate.md)
- - [DeviceGroupUpdate](docs/DeviceGroupUpdate.md)
- - [DeviceStatus](docs/DeviceStatus.md)
- - [EmmDevice](docs/EmmDevice.md)
- - [EnterprisePolicy](docs/EnterprisePolicy.md)
- - [EnterprisePolicyData](docs/EnterprisePolicyData.md)
- - [EnterprisePolicyDataDevicePasswordPolicy](docs/EnterprisePolicyDataDevicePasswordPolicy.md)
- - [EnterprisePolicyDataDeviceUpdatePolicy](docs/EnterprisePolicyDataDeviceUpdatePolicy.md)
- - [EnterprisePolicyDataFrpGoogles](docs/EnterprisePolicyDataFrpGoogles.md)
- - [EnterprisePolicyDataGoogleAccountPermission](docs/EnterprisePolicyDataGoogleAccountPermission.md)
- - [EnterprisePolicyDataPhonePolicy](docs/EnterprisePolicyDataPhonePolicy.md)
- - [EnterprisePolicyPartialUpdate](docs/EnterprisePolicyPartialUpdate.md)
- - [EnterpriseUpdateV1](docs/EnterpriseUpdateV1.md)
- - [EnterpriseV1](docs/EnterpriseV1.md)
- - [EventSubscription](docs/EventSubscription.md)
- - [EventSubscriptionArgs](docs/EventSubscriptionArgs.md)
- - [Geofence](docs/Geofence.md)
- - [GeofenceUpdate](docs/GeofenceUpdate.md)
- - [GoogleEMM](docs/GoogleEMM.md)
- - [GroupCommand](docs/GroupCommand.md)
- - [GroupCommandArgs](docs/GroupCommandArgs.md)
- - [GroupCommandRequest](docs/GroupCommandRequest.md)
- - [InlineResponse200](docs/InlineResponse200.md)
- - [InlineResponse2001](docs/InlineResponse2001.md)
- - [InlineResponse20010](docs/InlineResponse20010.md)
- - [InlineResponse20011](docs/InlineResponse20011.md)
- - [InlineResponse20012](docs/InlineResponse20012.md)
- - [InlineResponse20013](docs/InlineResponse20013.md)
- - [InlineResponse2002](docs/InlineResponse2002.md)
- - [InlineResponse2003](docs/InlineResponse2003.md)
- - [InlineResponse2004](docs/InlineResponse2004.md)
- - [InlineResponse2005](docs/InlineResponse2005.md)
- - [InlineResponse2006](docs/InlineResponse2006.md)
- - [InlineResponse2007](docs/InlineResponse2007.md)
- - [InlineResponse2008](docs/InlineResponse2008.md)
- - [InlineResponse2009](docs/InlineResponse2009.md)
- - [InlineResponse201](docs/InlineResponse201.md)
- - [InstallDevices](docs/InstallDevices.md)
- - [Owner](docs/Owner.md)
- - [TokenInfoV1](docs/TokenInfoV1.md)
- - [TokenRenewV0](docs/TokenRenewV0.md)
- - [V0CommandArgs](docs/V0CommandArgs.md)
- - [V0CommandRequest](docs/V0CommandRequest.md)
- - [V0CommandRequestStatus](docs/V0CommandRequestStatus.md)
- - [V0CommandScheduleArgs](docs/V0CommandScheduleArgs.md)
- - [V0CommandStatus](docs/V0CommandStatus.md)
-
+- [AppInstall](docs/AppInstall.md)
+- [AppInstallApplication](docs/AppInstallApplication.md)
+- [AppInstallVersion](docs/AppInstallVersion.md)
+- [AppPermission](docs/AppPermission.md)
+- [AppVersion](docs/AppVersion.md)
+- [Application](docs/Application.md)
+- [ApplicationVersion](docs/ApplicationVersion.md)
+- [CommandArgs](docs/CommandArgs.md)
+- [CommandRequest](docs/CommandRequest.md)
+- [Content](docs/Content.md)
+- [Data](docs/Data.md)
+- [Device](docs/Device.md)
+- [DeviceApp](docs/DeviceApp.md)
+- [DeviceAppPermission](docs/DeviceAppPermission.md)
+- [DeviceCommand](docs/DeviceCommand.md)
+- [DeviceGroup](docs/DeviceGroup.md)
+- [DeviceGroupPartialUpdate](docs/DeviceGroupPartialUpdate.md)
+- [DeviceGroupUpdate](docs/DeviceGroupUpdate.md)
+- [DeviceStatus](docs/DeviceStatus.md)
+- [EmmDevice](docs/EmmDevice.md)
+- [EnterprisePolicy](docs/EnterprisePolicy.md)
+- [EnterprisePolicyData](docs/EnterprisePolicyData.md)
+- [EnterprisePolicyDataDevicePasswordPolicy](docs/EnterprisePolicyDataDevicePasswordPolicy.md)
+- [EnterprisePolicyDataDeviceUpdatePolicy](docs/EnterprisePolicyDataDeviceUpdatePolicy.md)
+- [EnterprisePolicyDataFrpGoogles](docs/EnterprisePolicyDataFrpGoogles.md)
+- [EnterprisePolicyDataGoogleAccountPermission](docs/EnterprisePolicyDataGoogleAccountPermission.md)
+- [EnterprisePolicyDataPhonePolicy](docs/EnterprisePolicyDataPhonePolicy.md)
+- [EnterprisePolicyPartialUpdate](docs/EnterprisePolicyPartialUpdate.md)
+- [EnterpriseUpdateV1](docs/EnterpriseUpdateV1.md)
+- [EnterpriseV1](docs/EnterpriseV1.md)
+- [EventSubscription](docs/EventSubscription.md)
+- [EventSubscriptionArgs](docs/EventSubscriptionArgs.md)
+- [Geofence](docs/Geofence.md)
+- [GeofenceUpdate](docs/GeofenceUpdate.md)
+- [GoogleEMM](docs/GoogleEMM.md)
+- [GroupCommand](docs/GroupCommand.md)
+- [GroupCommandArgs](docs/GroupCommandArgs.md)
+- [GroupCommandRequest](docs/GroupCommandRequest.md)
+- [InlineResponse200](docs/InlineResponse200.md)
+- [InlineResponse2001](docs/InlineResponse2001.md)
+- [InlineResponse20010](docs/InlineResponse20010.md)
+- [InlineResponse20011](docs/InlineResponse20011.md)
+- [InlineResponse20012](docs/InlineResponse20012.md)
+- [InlineResponse20013](docs/InlineResponse20013.md)
+- [InlineResponse2002](docs/InlineResponse2002.md)
+- [InlineResponse2003](docs/InlineResponse2003.md)
+- [InlineResponse2004](docs/InlineResponse2004.md)
+- [InlineResponse2005](docs/InlineResponse2005.md)
+- [InlineResponse2006](docs/InlineResponse2006.md)
+- [InlineResponse2007](docs/InlineResponse2007.md)
+- [InlineResponse2008](docs/InlineResponse2008.md)
+- [InlineResponse2009](docs/InlineResponse2009.md)
+- [InlineResponse201](docs/InlineResponse201.md)
+- [InstallDevices](docs/InstallDevices.md)
+- [Owner](docs/Owner.md)
+- [TokenInfoV1](docs/TokenInfoV1.md)
+- [TokenRenewV0](docs/TokenRenewV0.md)
+- [V0CommandArgs](docs/V0CommandArgs.md)
+- [V0CommandRequest](docs/V0CommandRequest.md)
+- [V0CommandRequestStatus](docs/V0CommandRequestStatus.md)
+- [V0CommandScheduleArgs](docs/V0CommandScheduleArgs.md)
+- [V0CommandStatus](docs/V0CommandStatus.md)
 
 ## Documentation For Enums
 
- - [AppInstallStateEnum](docs/AppInstallStateEnum.md)
- - [DeviceCommandEnum](docs/DeviceCommandEnum.md)
- - [GroupCommandEnum](docs/GroupCommandEnum.md)
- - [SettingsGPSStateEnum](docs/SettingsGPSStateEnum.md)
- - [SettingsRotateStateEnum](docs/SettingsRotateStateEnum.md)
- - [SettingsVolumeStreamEnum](docs/SettingsVolumeStreamEnum.md)
- - [V0CommandScheduleArgsTimeTypeEnum](docs/V0CommandScheduleArgsTimeTypeEnum.md)
- - [V0CommandScheduleEnum](docs/V0CommandScheduleEnum.md)
- - [V0DeviceCommandEnum](docs/V0DeviceCommandEnum.md)
-
+- [AppInstallStateEnum](docs/AppInstallStateEnum.md)
+- [DeviceCommandEnum](docs/DeviceCommandEnum.md)
+- [GroupCommandEnum](docs/GroupCommandEnum.md)
+- [SettingsGPSStateEnum](docs/SettingsGPSStateEnum.md)
+- [SettingsRotateStateEnum](docs/SettingsRotateStateEnum.md)
+- [SettingsVolumeStreamEnum](docs/SettingsVolumeStreamEnum.md)
+- [V0CommandScheduleArgsTimeTypeEnum](docs/V0CommandScheduleArgsTimeTypeEnum.md)
+- [V0CommandScheduleEnum](docs/V0CommandScheduleEnum.md)
+- [V0DeviceCommandEnum](docs/V0DeviceCommandEnum.md)
 
 ## Documentation For Authorization
-
 
 ## apiKey
 
@@ -223,11 +446,20 @@ Class | Method | HTTP request
 - **API key parameter name**: Authorization
 - **Location**: HTTP header
 
-
 ## Author
 
 developer@esper.io
 
+## Additional Resources
+
+- **Esper Documentation**: [https://docs.esper.io](https://docs.esper.io)
+- **Esper Website**: [https://esper.io](https://esper.io)
+- **Python SDK Documentation**: [https://docs.esper.io/home/pythonsdk.html](https://docs.esper.io/home/pythonsdk.html)
+- **GitHub Repository**: [https://github.com/esper-io/esper-client-py](https://github.com/esper-io/esper-client-py)
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## License
 
@@ -244,3 +476,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+## Support
+
+For support, please contact:
+- **Email**: developer@esper.io
+- **Gitter**: [esper-dev/esper-sdk](https://gitter.im/esper-dev/esper-sdk)

--- a/docs/AppInstallVersion.md
+++ b/docs/AppInstallVersion.md
@@ -8,7 +8,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **app_version_id** | **str** |  | [optional] 
 **version_code** | **str** |  | [optional] 
-**build_number** | **str** |  | [optional] 
+**version_name** | **str** | Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false. | [optional]
+**build_number** | **str** | Deprecated. Use version_code instead. | [optional] 
 **hash_string** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/AppVersion.md
+++ b/docs/AppVersion.md
@@ -12,7 +12,8 @@ Name | Type | Description | Notes
 **app_file** | **str** |  | [optional] 
 **app_icon** | **str** |  | [optional] 
 **version_code** | **str** |  | 
-**build_number** | **str** |  | [optional] 
+**version_name** | **str** | Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false. | [optional]
+**build_number** | **str** | Deprecated. Use version_code instead. | [optional] 
 **size_in_mb** | **float** |  | [optional] 
 **hash_string** | **str** |  | [optional] 
 **release_name** | **str** |  | [optional] 

--- a/docs/ApplicationApi.md
+++ b/docs/ApplicationApi.md
@@ -182,7 +182,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_app_version**
-> AppVersion get_app_version(version_id, application_id, enterprise_id)
+> AppVersion get_app_version(version_id, application_id, enterprise_id, legacy_format=legacy_format)
 
 Get app version information
 
@@ -204,10 +204,11 @@ api_instance = esperclient.ApplicationApi(esperclient.ApiClient(configuration))
 version_id = 'version_id_example' # str | A UUID string identifying this app version.
 application_id = 'application_id_example' # str | A UUID string identifying this application.
 enterprise_id = 'enterprise_id_example' # str | A UUID string identifying enterprise.
+legacy_format = False # bool | If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. (optional)
 
 try:
     # Get app version information
-    api_response = api_instance.get_app_version(version_id, application_id, enterprise_id)
+    api_response = api_instance.get_app_version(version_id, application_id, enterprise_id, legacy_format=legacy_format)
     print(api_response)
 except ApiException as e:
     print("Exception when calling ApplicationApi->get_app_version: %s\n" % e)
@@ -220,6 +221,7 @@ Name | Type | Description  | Notes
  **version_id** | [**str**](.md)| A UUID string identifying this app version. | 
  **application_id** | [**str**](.md)| A UUID string identifying this application. | 
  **enterprise_id** | **str**| A UUID string identifying enterprise. | 
+ **legacy_format** | **bool**| If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. | [optional] 
 
 ### Return type
 
@@ -237,7 +239,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_app_versions**
-> InlineResponse2001 get_app_versions(application_id, enterprise_id, version_code=version_code, build_number=build_number, limit=limit, offset=offset)
+> InlineResponse2001 get_app_versions(application_id, enterprise_id, version_code=version_code, build_number=build_number, legacy_format=legacy_format, limit=limit, offset=offset)
 
 List App versions
 
@@ -260,12 +262,13 @@ application_id = 'application_id_example' # str | A UUID string identifying this
 enterprise_id = 'enterprise_id_example' # str | A UUID string identifying enterprise.
 version_code = 'version_code_example' # str | filter by version code (optional)
 build_number = 'build_number_example' # str | filter by build number (optional)
+legacy_format = False # bool | If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. (optional)
 limit = 20 # int | Number of results to return per page. (optional) (default to 20)
 offset = 0 # int | The initial index from which to return the results. (optional) (default to 0)
 
 try:
     # List App versions
-    api_response = api_instance.get_app_versions(application_id, enterprise_id, version_code=version_code, build_number=build_number, limit=limit, offset=offset)
+    api_response = api_instance.get_app_versions(application_id, enterprise_id, version_code=version_code, build_number=build_number, legacy_format=legacy_format, limit=limit, offset=offset)
     print(api_response)
 except ApiException as e:
     print("Exception when calling ApplicationApi->get_app_versions: %s\n" % e)
@@ -279,6 +282,7 @@ Name | Type | Description  | Notes
  **enterprise_id** | **str**| A UUID string identifying enterprise. | 
  **version_code** | **str**| filter by version code | [optional] 
  **build_number** | **str**| filter by build number | [optional] 
+ **legacy_format** | **bool**| If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. | [optional] 
  **limit** | **int**| Number of results to return per page. | [optional] [default to 20]
  **offset** | **int**| The initial index from which to return the results. | [optional] [default to 0]
 

--- a/docs/ApplicationVersion.md
+++ b/docs/ApplicationVersion.md
@@ -8,7 +8,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **str** |  | [optional] 
 **version_code** | **str** |  | [optional] 
-**build_number** | **str** |  | [optional] 
+**version_name** | **str** | Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false. | [optional]
+**build_number** | **str** | Deprecated. Use version_code instead. | [optional] 
 **hash_string** | **str** |  | [optional] 
 **min_sdk_version** | **str** |  | [optional] 
 **target_sdk_version** | **str** |  | [optional] 

--- a/esperclient/api/application_api.py
+++ b/esperclient/api/application_api.py
@@ -387,6 +387,7 @@ class ApplicationApi(object):
         :param str version_id: A UUID string identifying this app version. (required)
         :param str application_id: A UUID string identifying this application. (required)
         :param str enterprise_id: A UUID string identifying enterprise. (required)
+        :param bool legacy_format: If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. (optional)
         :return: AppVersion
                  If the method is called asynchronously,
                  returns the request thread.
@@ -411,12 +412,13 @@ class ApplicationApi(object):
         :param str version_id: A UUID string identifying this app version. (required)
         :param str application_id: A UUID string identifying this application. (required)
         :param str enterprise_id: A UUID string identifying enterprise. (required)
+        :param bool legacy_format: If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. (optional)
         :return: AppVersion
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['version_id', 'application_id', 'enterprise_id']
+        all_params = ['version_id', 'application_id', 'enterprise_id', 'legacy_format']
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -455,6 +457,12 @@ class ApplicationApi(object):
             path_params['enterprise_id'] = params['enterprise_id']
 
         query_params = []
+        if 'legacy_format' in params:
+            # Convert boolean to lowercase string for API compatibility
+            legacy_format_val = params['legacy_format']
+            if isinstance(legacy_format_val, bool):
+                legacy_format_val = str(legacy_format_val).lower()
+            query_params.append(('legacy_format', legacy_format_val))
 
         header_params = {}
 
@@ -499,6 +507,7 @@ class ApplicationApi(object):
         :param str enterprise_id: A UUID string identifying enterprise. (required)
         :param str version_code: filter by version code
         :param str build_number: filter by build number
+        :param bool legacy_format: If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. (optional)
         :param int limit: Number of results to return per page.
         :param int offset: The initial index from which to return the results.
         :return: InlineResponse2001
@@ -526,6 +535,7 @@ class ApplicationApi(object):
         :param str enterprise_id: A UUID string identifying enterprise. (required)
         :param str version_code: filter by version code
         :param str build_number: filter by build number
+        :param bool legacy_format: If False, returns standardized format with version_name and version_code (build_number removed). If True or not specified, returns legacy format. (optional)
         :param int limit: Number of results to return per page.
         :param int offset: The initial index from which to return the results.
         :return: InlineResponse2001
@@ -533,7 +543,7 @@ class ApplicationApi(object):
                  returns the request thread.
         """
 
-        all_params = ['application_id', 'enterprise_id', 'version_code', 'build_number', 'limit', 'offset']
+        all_params = ['application_id', 'enterprise_id', 'version_code', 'build_number', 'legacy_format', 'limit', 'offset']
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -570,6 +580,12 @@ class ApplicationApi(object):
             query_params.append(('version_code', params['version_code']))
         if 'build_number' in params:
             query_params.append(('build_number', params['build_number']))
+        if 'legacy_format' in params:
+            # Convert boolean to lowercase string for API compatibility
+            legacy_format_val = params['legacy_format']
+            if isinstance(legacy_format_val, bool):
+                legacy_format_val = str(legacy_format_val).lower()
+            query_params.append(('legacy_format', legacy_format_val))
         if 'limit' in params:
             query_params.append(('limit', params['limit']))
         if 'offset' in params:

--- a/esperclient/models/app_install_version.py
+++ b/esperclient/models/app_install_version.py
@@ -46,6 +46,7 @@ class AppInstallVersion(object):
     swagger_types = {
         'app_version_id': 'str',
         'version_code': 'str',
+        'version_name': 'str',
         'build_number': 'str',
         'hash_string': 'str'
     }
@@ -53,15 +54,17 @@ class AppInstallVersion(object):
     attribute_map = {
         'app_version_id': 'app_version_id',
         'version_code': 'version_code',
+        'version_name': 'version_name',
         'build_number': 'build_number',
         'hash_string': 'hash_string'
     }
 
-    def __init__(self, app_version_id=None, version_code=None, build_number=None, hash_string=None):
+    def __init__(self, app_version_id=None, version_code=None, version_name=None, build_number=None, hash_string=None):
         """AppInstallVersion - a model defined in Swagger"""
 
         self._app_version_id = None
         self._version_code = None
+        self._version_name = None
         self._build_number = None
         self._hash_string = None
         self.discriminator = None
@@ -70,6 +73,8 @@ class AppInstallVersion(object):
             self.app_version_id = app_version_id
         if version_code is not None:
             self.version_code = version_code
+        if version_name is not None:
+            self.version_name = version_name
         if build_number is not None:
             self.build_number = build_number
         if hash_string is not None:
@@ -116,6 +121,33 @@ class AppInstallVersion(object):
         """
 
         self._version_code = version_code
+
+    @property
+    def version_name(self):
+        """Gets the version_name of this AppInstallVersion.
+
+        Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false.
+
+        :return: The version_name of this AppInstallVersion.
+        :rtype: str
+        """
+        return self._version_name
+
+    @version_name.setter
+    def version_name(self, version_name):
+        """Sets the version_name of this AppInstallVersion.
+
+        Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false.
+
+        :param version_name: The version_name of this AppInstallVersion.
+        :type: str
+        """
+        if version_name is not None and len(version_name) > 128:
+            raise ValueError("Invalid value for `version_name`, length must be less than or equal to `128`")
+        if version_name is not None and len(version_name) < 1:
+            raise ValueError("Invalid value for `version_name`, length must be greater than or equal to `1`")
+
+        self._version_name = version_name
 
     @property
     def build_number(self):

--- a/esperclient/models/app_version.py
+++ b/esperclient/models/app_version.py
@@ -52,6 +52,7 @@ class AppVersion(object):
         'app_file': 'str',
         'app_icon': 'str',
         'version_code': 'str',
+        'version_name': 'str',
         'build_number': 'str',
         'size_in_mb': 'float',
         'hash_string': 'str',
@@ -74,6 +75,7 @@ class AppVersion(object):
         'app_file': 'app_file',
         'app_icon': 'app_icon',
         'version_code': 'version_code',
+        'version_name': 'version_name',
         'build_number': 'build_number',
         'size_in_mb': 'size_in_mb',
         'hash_string': 'hash_string',
@@ -89,7 +91,7 @@ class AppVersion(object):
         'application': 'application'
     }
 
-    def __init__(self, id=None, installed_count=None, permissions=None, app_file=None, app_icon=None, version_code=None, build_number=None, size_in_mb=None, hash_string=None, release_name=None, release_comments=None, release_track=None, created_on=None, updated_on=None, min_sdk_version=None, target_sdk_version=None, is_enabled=None, enterprise=None, application=None):
+    def __init__(self, id=None, installed_count=None, permissions=None, app_file=None, app_icon=None, version_code=None, version_name=None, build_number=None, size_in_mb=None, hash_string=None, release_name=None, release_comments=None, release_track=None, created_on=None, updated_on=None, min_sdk_version=None, target_sdk_version=None, is_enabled=None, enterprise=None, application=None):
         """AppVersion - a model defined in Swagger"""
 
         self._id = None
@@ -98,6 +100,7 @@ class AppVersion(object):
         self._app_file = None
         self._app_icon = None
         self._version_code = None
+        self._version_name = None
         self._build_number = None
         self._size_in_mb = None
         self._hash_string = None
@@ -123,6 +126,8 @@ class AppVersion(object):
         if app_icon is not None:
             self.app_icon = app_icon
         self.version_code = version_code
+        if version_name is not None:
+            self.version_name = version_name
         if build_number is not None:
             self.build_number = build_number
         if size_in_mb is not None:
@@ -307,6 +312,33 @@ class AppVersion(object):
             raise ValueError("Invalid value for `build_number`, length must be greater than or equal to `1`")
 
         self._build_number = build_number
+
+    @property
+    def version_name(self):
+        """Gets the version_name of this AppVersion.
+
+        Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false.
+
+        :return: The version_name of this AppVersion.
+        :rtype: str
+        """
+        return self._version_name
+
+    @version_name.setter
+    def version_name(self, version_name):
+        """Sets the version_name of this AppVersion.
+
+        Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false.
+
+        :param version_name: The version_name of this AppVersion.
+        :type: str
+        """
+        if version_name is not None and len(version_name) > 128:
+            raise ValueError("Invalid value for `version_name`, length must be less than or equal to `128`")
+        if version_name is not None and len(version_name) < 1:
+            raise ValueError("Invalid value for `version_name`, length must be greater than or equal to `1`")
+
+        self._version_name = version_name
 
     @property
     def size_in_mb(self):

--- a/esperclient/models/application_version.py
+++ b/esperclient/models/application_version.py
@@ -46,6 +46,7 @@ class ApplicationVersion(object):
     swagger_types = {
         'id': 'str',
         'version_code': 'str',
+        'version_name': 'str',
         'build_number': 'str',
         'hash_string': 'str',
         'min_sdk_version': 'str',
@@ -56,6 +57,7 @@ class ApplicationVersion(object):
     attribute_map = {
         'id': 'id',
         'version_code': 'version_code',
+        'version_name': 'version_name',
         'build_number': 'build_number',
         'hash_string': 'hash_string',
         'min_sdk_version': 'min_sdk_version',
@@ -63,11 +65,12 @@ class ApplicationVersion(object):
         'download_url': 'download_url'
     }
 
-    def __init__(self, id=None, version_code=None, build_number=None, hash_string=None, min_sdk_version=None, target_sdk_version=None, download_url=None):
+    def __init__(self, id=None, version_code=None, version_name=None, build_number=None, hash_string=None, min_sdk_version=None, target_sdk_version=None, download_url=None):
         """ApplicationVersion - a model defined in Swagger"""
 
         self._id = None
         self._version_code = None
+        self._version_name = None
         self._build_number = None
         self._hash_string = None
         self._min_sdk_version = None
@@ -79,6 +82,8 @@ class ApplicationVersion(object):
             self.id = id
         if version_code is not None:
             self.version_code = version_code
+        if version_name is not None:
+            self.version_name = version_name
         if build_number is not None:
             self.build_number = build_number
         if hash_string is not None:
@@ -135,6 +140,33 @@ class ApplicationVersion(object):
             raise ValueError("Invalid value for `version_code`, length must be greater than or equal to `1`")
 
         self._version_code = version_code
+
+    @property
+    def version_name(self):
+        """Gets the version_name of this ApplicationVersion.
+
+        Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false.
+
+        :return: The version_name of this ApplicationVersion.
+        :rtype: str
+        """
+        return self._version_name
+
+    @version_name.setter
+    def version_name(self, version_name):
+        """Sets the version_name of this ApplicationVersion.
+
+        Human-readable version string (e.g., "1.0.02"). Available when legacy_format=false.
+
+        :param version_name: The version_name of this ApplicationVersion.
+        :type: str
+        """
+        if version_name is not None and len(version_name) > 128:
+            raise ValueError("Invalid value for `version_name`, length must be less than or equal to `128`")
+        if version_name is not None and len(version_name) < 1:
+            raise ValueError("Invalid value for `version_name`, length must be greater than or equal to `1`")
+
+        self._version_name = version_name
 
     @property
     def build_number(self):


### PR DESCRIPTION
**Key Points:**

- Default behavior: Uses legacy format (build_number) by default
- New format: Available via --legacy-format false
- No breaking changes: Existing scripts continue to work without modification
- Migration: Users can opt into the new format when ready
- The plan now reflects that legacy format remains the default for backward compatibility, with the new standardized format available as an opt-in option.
- Backward compatibility: Legacy format is now the default, so existing scripts continue to work
